### PR TITLE
Remove unused use-statement

### DIFF
--- a/t/logic.t
+++ b/t/logic.t
@@ -1,6 +1,5 @@
 use v6;
 use Test;
-use File::Temp;
 
 use lib 't/lib';
 use PFTest;


### PR DESCRIPTION
`File::Temp` is not required by the test code itself. Yet, if the statement is placed before `use PFTest` then it sometimes triggers a bug in MoarVM which results in corrupted deserialization of precompiled files.